### PR TITLE
Add --dataset-path flag to ift script

### DIFF
--- a/06_ift/train.py
+++ b/06_ift/train.py
@@ -1,12 +1,19 @@
 from lamini import Lamini
 
+import argparse
 import jsonlines
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Lamini training script.")
+    parser.add_argument('--dataset-path', type=str,
+                        default="data/results/generated_q_a.jsonl",
+                        help='Path to the training dataset')
+    args = parser.parse_args()
+
     llm = Lamini(model_name="meta-llama/Meta-Llama-3-8B-Instruct")
 
-    dataset = list(load_training_data()) * 10
+    dataset = list(load_training_data(args.dataset_path)) * 10
 
     llm.train(
         data_or_dataset_id=dataset,
@@ -18,9 +25,7 @@ def main():
     )
 
 
-def load_training_data():
-    path = "/app/lamini-earnings-sdk/data/results/generated_q_a.jsonl"
-
+def load_training_data(path: str):
     limit = 10
 
     with jsonlines.open(path) as reader:


### PR DESCRIPTION
1. We'll include in the markdown doc the command with the right value in --dataset-path
2. This approach saves the need to update code.

Manually tested, and was able to submit training job correctly.