### PR TITLE
Remove defunct Lamini Logo from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<img src="https://avatars.githubusercontent.com/u/130713213?s=200&v=4" width="110"><img src="https://huggingface.co/lamini/instruct-peft-tuned-12b/resolve/main/Lamini_logo.png?max-height=110" height="110">
+<img src="https://avatars.githubusercontent.com/u/130713213?s=200&v=4" width="110">
 </div>
 <div align="center">
 


### PR DESCRIPTION
As shown, the logo cannot be displayed

![image](https://github.com/user-attachments/assets/86affebb-777d-4fa1-b222-270cd276cc3d)
